### PR TITLE
Update berks cookbooks for cwb-server

### DIFF
--- a/cookbooks/cwb-server/berks-cookbooks/cwb-server/attributes/default.rb
+++ b/cookbooks/cwb-server/berks-cookbooks/cwb-server/attributes/default.rb
@@ -12,9 +12,7 @@ default['cwb-server']['app']['dir'] = '/var/www/cloud-workbench'
 default['cwb-server']['app']['log_dir'] = "/var/log/#{node['cwb-server']['app']['name']}"
 default['cwb-server']['app']['repo'] = 'https://github.com/sealuzh/cloud-workbench.git'
 # A branch, tag, or commit to be synchronized with git
-# TODO: switch back to default master after testing/merging
-# default['cwb-server']['app']['branch'] = 'master'
-default['cwb-server']['app']['branch'] = 'support/update-installation'
+default['cwb-server']['app']['branch'] = 'master'
 default['cwb-server']['app']['rollback_on_error'] = false
 default['cwb-server']['app']['num_workers'] = 2
 # Should be a multiple of 1000 according to foreman: http://ddollar.github.io/foreman/#EXPORTING


### PR DESCRIPTION
The wrong branch was configured in attributes.
Switched to master branch now.
