### PR TITLE
Fix/nginx login config

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ tail -f /var/log/nginx/cloud-workbench-error.log
 cd /var/www/cloud-workbench/current
 # Storage directory (where materialized Vagrantfiles are stored)
 cd /var/www/cloud-workbench/shared/storage/production
-# NGING proxy
+# NGING proxy (sudo nginx -s reload)
 cat /etc/nginx/sites-available/cloud-workbench
 # PostgreSQL database (sudo su postgres)
 ls /var/lib/postgresql/9.6/main

--- a/cookbooks/cwb-server/berks-cookbooks/cwb-server/templates/default/nginx.vhost.conf.erb
+++ b/cookbooks/cwb-server/berks-cookbooks/cwb-server/templates/default/nginx.vhost.conf.erb
@@ -33,6 +33,8 @@ server {
 
   # Rate-limit login page
   location /users/sign_in {
+    try_files $uri $uri.html
+              @app;
     limit_req zone=mylimit burst=10;
     proxy_pass        http://cloud-workbench;
   }

--- a/cookbooks/cwb-server/templates/default/nginx.vhost.conf.erb
+++ b/cookbooks/cwb-server/templates/default/nginx.vhost.conf.erb
@@ -33,6 +33,8 @@ server {
 
   # Rate-limit login page
   location /users/sign_in {
+    try_files $uri $uri.html
+              @app;
     limit_req zone=mylimit burst=10;
     proxy_pass        http://cloud-workbench;
   }


### PR DESCRIPTION
## Problem

Authentication fails (unverified request) if NGINX does not set the real IP header as done in the `@app` section.

```none
proxy_set_header  X-Real-IP           $remote_addr;
```

## Solution

Use `try_files` and reference the @app config